### PR TITLE
Fix win32 backend

### DIFF
--- a/src/winmsg.rs
+++ b/src/winmsg.rs
@@ -57,8 +57,8 @@ impl<'a> BeInternal<'a> {
 pub struct Backend<'a>(Box<BeInternal<'a>>);
 
 impl SendFnOnce for Arc<OwnedHwnd> {
-    fn send(&self, f: Box<FnOnce() + Send + 'static>) -> Result<(), MainLoopError> {
-        let cb = CbKind::Asap(f.into());
+    fn send(&self, f: Box<dyn FnOnce() + Send + 'static>) -> Result<(), MainLoopError> {
+        let cb = CbKind::Asap(f as _);
         let x = Box::into_raw(Box::new(cb));
         unsafe {
             winuser::PostMessageA(self.0, WM_CALL_THREAD, x as usize, 0);
@@ -135,7 +135,7 @@ impl<'a> Drop for Backend<'a> {
 }
 
 impl<'a> Backend<'a> {
-    pub (crate) fn new() -> Result<(Self, Box<SendFnOnce>), MainLoopError> {
+    pub (crate) fn new() -> Result<(Self, Box<dyn SendFnOnce>), MainLoopError> {
         ensure_window_class();
         //println!("call CreateWindowExA");
         let wnd = unsafe { winuser::CreateWindowExA(


### PR DESCRIPTION
Got error on win32 backend before:

```rust
error[E0277]: the trait bound `std::boxed::Box<dyn std::ops::FnOnce()>: std::convert::From<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>` is not satisfied
  --> C:\Users\tmtu\.cargo\registry\src\github.com-1ecc6299db9ec823\thin_main_loop-0.2.0\src\winmsg.rs:61:31
   |
61 |         let cb = CbKind::Asap(f.into());
   |                               ^^^^^^^^ the trait `std::convert::From<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>` is not implemented for `std::boxed::Box<dyn std::ops::FnOnce()>`
   |
   = help: the following implementations were found:
             <std::boxed::Box<(dyn std::error::Error + 'a)> as std::convert::From<E>>
             <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<&str>>
             <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<std::borrow::Cow<'a, str>>>
             <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<std::string::String>>
           and 16 others
   = note: required because of the requirements on the impl of `std::convert::Into<std::boxed::Box<dyn std::ops::FnOnce()>>` for `std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>`

error: aborting due to previous error
```